### PR TITLE
ENTESB-12238: [SB2] Quickstarts arquillian test fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- configure the Fuse version you want to use here -->
-        <fuse.bom.version>7.6.0.fuse-sb2-760014</fuse.bom.version>
+        <fuse.bom.version>7.8.0.fuse-sb2-780010</fuse.bom.version>
 
         <!-- maven plugin versions -->
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
@@ -112,7 +112,13 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-assertions</artifactId>
+            <artifactId>kubernetes-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/io/fabric8/quickstarts/camel/config/KubernetesIntegrationKT.java
+++ b/src/test/java/io/fabric8/quickstarts/camel/config/KubernetesIntegrationKT.java
@@ -15,15 +15,18 @@
  */
 package io.fabric8.quickstarts.camel.config;
 
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
-
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import org.arquillian.cube.kubernetes.api.Session;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -32,8 +35,20 @@ public class KubernetesIntegrationKT {
     @ArquillianResource
     KubernetesClient client;
 
+    @ArquillianResource
+    public Session session;
+
     @Test
     public void testAppProvisionsRunningPods() throws Exception {
-        assertThat(client).deployments().pods().isPodReadyForPeriod();
+        boolean foundReadyPod = false;
+
+        PodList podList = client.pods().inNamespace(session.getNamespace()).list();
+        for (Pod p : podList.getItems()) {
+            if (!p.getMetadata().getName().endsWith("build") && !p.getMetadata().getName().endsWith("deploy")) {
+                assertTrue(p.getMetadata().getName() + " is not ready", Readiness.isReady(p));
+                foundReadyPod = true;
+            }
+        }
+        assertTrue("Found no ready pods in namespace", foundReadyPod);
     }
 }


### PR DESCRIPTION
Removed kubernetes-assertion dependency in favor of kubernetes-client