### PR TITLE
ENTESB-14969 Link Secrets Creation page to Quickstarts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,16 +37,15 @@ The most effective way to run this quickstart is to deploy and run the project o
 
 For more details about running this quickstart on a single-node OpenShift cluster, CI/CD deployments, as well as the rest of the runtime, see the link:http://appdev.openshift.io/docs/spring-boot-runtime.html[Spring Boot Runtime Guide].
 
-== Running the Quickstart on a single-node Kubernetes/OpenShift cluster
+== Running the Quickstart on a single-node Kubernetese/OpenShift cluster
 
 IMPORTANT: You need to run this example on Container Development Kit 3.3 or OpenShift 3.7.
 Both of these products have suitable Fuse images pre-installed.
 If you run it in an environment where those images are not preinstalled follow the steps described in <<single-node-without-preinstalled-images>>.
 
-A single-node Kubernetes/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
-If you have a single-node Kubernetes/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
-
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
 
 . Log in to your OpenShift cluster:
 +
@@ -96,12 +95,11 @@ Wait until you can see that the pod for the `spring-boot-camel-config` has start
 . Switch to tab `Logs` and then see the messages sent by Camel.
 
 [#single-node-without-preinstalled-images]
-=== Running the Quickstart on a single-node Kubernetes/OpenShift cluster without preinstalled images
+=== Running the Quickstart on a single-node Kubernetese/OpenShift cluster without preinstalled images
 
-A single-node Kubernetes/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
-If you have a single-node Kubernetes/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
-
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
 
 . Log in to your OpenShift cluster:
 +
@@ -117,11 +115,14 @@ $ oc login -u developer -p developer
 $ oc new-project MY_PROJECT_NAME
 ----
 
-. Import base images in your newly created project (MY_PROJECT_NAME):
+. Configure Red Hat Container Registry authentication (if it is not configured).
+Follow https://access.redhat.com/documentation/en-us/red_hat_fuse/7.9/html-single/fuse_on_openshift_guide/index#configure-container-registry[documentation].
+
+. Import base images in your newly created project (MY_PROJECT_NAME). :
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc import-image fis-java-openshift:2.0 --from=registry.access.redhat.com/jboss-fuse-6/fis-java-openshift:2.0 --confirm
+$ oc import-image fuse-java-openshift:1.9 --from=registry.redhat.io/fuse7/fuse-java-openshift:1.9 --confirm
 ----
 
 . Change the directory to the folder that contains the extracted quickstart application (for example, `my_openshift/spring-boot-camel-config`) :
@@ -147,29 +148,30 @@ $ oc create -f sample-configmap.yml
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean -DskipTests oc:deploy -Popenshift -Djkube.generator.fromMode=istag -Djkube.generator.from=MY_PROJECT_NAME/fis-java-openshift:2.0
+$ mvn clean -DskipTests oc:deploy -Popenshift -Djkube.generator.fromMode=istag -D=jkube.generator.from=MY_PROJECT_NAME/fuse-java-openshift:1.9
 ----
 
 . In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
 Wait until you can see that the pod for the `spring-boot-camel-config` has started up.
 
-. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-config` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/rc/spring-boot-camel-config-xml-NUMBER_OF_DEPLOYMENT?tab=details`.
+. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-config` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/rc/spring-boot-camel-config-NUMBER_OF_DEPLOYMENT?tab=details`.
 
 . Switch to tab `Logs` and then see the messages sent by Camel.
 
 == Integration Testing
 
-The example includes a https://github.com/fabric8io/fabric8/tree/master/components/fabric8-arquillian[fabric8 arquillian] Kubernetes Integration Test.
-Once the container image has been built and deployed in Kubernetes, the integration test can be run with:
+The example includes a https://github.com/fabric8io/fabric8/tree/master/components/fabric8-arquillian[fabric8 arquillian] Kubernetese Integration Test.
+Once the container image has been built and deployed in Kubernetese, the integration test can be run with:
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 mvn test -Dtest=*KT
 ----
 
-The test is disabled by default and has to be enabled using `-Dtest`. https://fabric8.io/guide/testing.html[Integration Testing] and https://fabric8.io/guide/arquillian.html[Fabric8 Arquillian Extension] provide more information on writing full fledged black box integration tests for Kubernetes.
+The test is disabled by default and has to be enabled using `-Dtest`. https://fabric8.io/guide/testing.html[Integration Testing] and https://fabric8.io/guide/arquillian.html[Fabric8 Arquillian Extension] provide more information on writing full fledged black box integration tests for Kubernetese.
 
 == Running the quickstart standalone on your machine
+
 To run this quickstart as a standalone project on your local machine:
 
 . Download the project and extract the archive on your local filesystem.
@@ -187,4 +189,9 @@ $ mvn clean package
 ----
 $ mvn spring-boot:run
 ----
+
 . See the messages sent by Camel.
+
+---
+
+Generated by maven plugin - do NOT edit this file! (See https://github.com/jboss-fuse/documentation-template/blob/main/README.md[documentation])

--- a/src/main/doc/introduction.adoc
+++ b/src/main/doc/introduction.adoc
@@ -1,0 +1,25 @@
+= Spring-Boot Camel QuickStart using ConfigMaps and Secrets
+
+This quickstart demonstrates how to configure a Spring-Boot application using Kubernetes ConfigMaps and Secrets.
+
+A route generates sample messages that are delivered to a list of recipient endpoints
+configured through a property named `quickstart.recipients` in the `src/main/resources/application.properties` file.
+The property can be overridden using a Kubernetes ConfigMap object.
+As soon as a ConfigMap named `camel-config` (containing a property named `application.properties`) is created or changed in the namespace,
+ an application-context refresh event will be triggered and the logs will reflect the new configuration.
+ A sample `ConfigMap` (`sample-configmap.yml`) is contained in this repository (it changes the configuration to use all available endpoints in the `recipientList`).
+
+The quickstart will run on Openshift using a `ServiceAccount` named `qs-camel-config`, with the `view` role granted.
+This way, the application is allowed to read the `ConfigMap` and to listen for changes in the current Openshift project.
+
+Secrets can also be used to configure the application (a sample username/password combination is configured using secrets in this quickstart).
+Unlike the `ConfigMap` objects, secrets require higher permissions in order to be read using the Openshift APIs.
+To overcome this security limitation, the approach used in this quickstart is to mount the secret as a volume in the Pod and
+configure its location in the spring-cloud config file (`src/main/resources/bootstrap.yml`).
+
+A sample secret (`sample-secret.yml`) is contained in this repository (it just replaces the username `wrong-username` with `myuser`).
+
+**Note: a secret named `camel-config` must be present in the namespace before the application is deployed**
+(otherwise the container remains in a pending status, waiting for it).
+
+The application utilizes the Spring http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/ImportResource.html[`@ImportResource`] annotation to load a Camel Context definition via a _src/main/resources/spring/camel-context.xml_ file on the classpath.

--- a/src/main/doc/oc-special-configuration.adoc
+++ b/src/main/doc/oc-special-configuration.adoc
@@ -1,0 +1,12 @@
+
+. Create the (**required**) secret:
++
+----
+$ oc create -f sample-secret.yml
+----
+
+. Create the ConfigMap (the ConfigMap can be also created after the application has been deployed, to see the live-reload feature in action):
++
+----
+$ oc create -f sample-configmap.yml
+----


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-14969

Change refactors quickstart to use a template for documentation + template adds missing instruction to add secret.